### PR TITLE
Configure development project

### DIFF
--- a/bases/agent/resources/agent/system.edn
+++ b/bases/agent/resources/agent/system.edn
@@ -1,6 +1,5 @@
 {:system/env
  #profile {:dev :dev
-           :test :test
            :prod :prod}
 
  :server/http

--- a/development/src/dev/agent.clj
+++ b/development/src/dev/agent.clj
@@ -1,0 +1,27 @@
+(ns dev.agent
+  (:require
+    [aero.core :refer [read-config]]
+    [clojure.java.io :as io]
+    [clojure.tools.namespace.repl :as repl]
+    [com.vennbilling.agent.core]
+    [integrant.core :as ig]
+    [integrant.repl :refer [prep go halt reset init]]
+    [integrant.repl.state]))
+
+
+(def config-file (io/resource "../../../bases/agent/resources/agent/system.edn"))
+(def config (read-config config-file {:profile :dev}))
+
+(integrant.repl/set-prep! #(ig/prep config))
+(repl/set-refresh-dirs "../../../bases/agent/src")
+
+
+;; Helpers to start and stop the agent
+(comment
+  (prep)
+  (init)
+  integrant.repl.state/config
+  integrant.repl.state/system
+  (go)
+  (halt)
+  (reset))


### PR DESCRIPTION
Now that we are using polylith, we should configure the development project.

This is mostly a mirror from the old [env/dev/user.clj](https://github.com/vennbilling/venn/blob/v0.0.2/env/dev/clj/user.clj) from v0.0.2